### PR TITLE
Feature/backend options and more expectation values

### DIFF
--- a/pennylane_qiskit/devices.py
+++ b/pennylane_qiskit/devices.py
@@ -60,7 +60,7 @@ from qiskit.converters import dag_to_circuit, circuit_to_dag
 from qiskit.extensions import XGate, RXGate, U1Gate, HGate, RYGate, RZGate, CzGate, CnotGate, YGate, ZGate, SGate, \
     TGate, U2Gate, U3Gate, SwapGate
 from qiskit.providers import BaseProvider, BaseJob, BaseBackend
-from qiskit.providers.aer import QasmSimulator, StatevectorSimulator, UnitarySimulator
+from qiskit.providers.aer import StatevectorSimulator, UnitarySimulator
 from qiskit.providers.aer.backends.aerbackend import AerBackend
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.basicaer import QasmSimulatorPy, StatevectorSimulatorPy, UnitarySimulatorPy
@@ -70,7 +70,9 @@ from ._version import __version__
 from .qiskitops import BasisState, Rot, QubitStateVector, QubitUnitary, QiskitInstructions
 
 """
-This
+This is the core mapping of PennyLane operations to qiskit's operations.
+It can be both :code:`Gate` or a :code:`QiskitInstructions` which will 
+later be handled differently.
 """
 QISKIT_OPERATION_MAP = {
     # native PennyLane operations also native to qiskit

--- a/pennylane_qiskit/devices.py
+++ b/pennylane_qiskit/devices.py
@@ -166,8 +166,13 @@ class QiskitDevice(Device):
             wires (Sequence[int]): subsystems the operation is applied on
             par (tuple): parameters for the operation
         """
-
-        mapped_operation = self._operation_map[operation]
+        try:
+            mapped_operation = self._operation_map[operation]
+        except KeyError:
+            msg = "The operation is not of an expected type. "
+            msg += "Supported QISKIT operations and instructions are: "
+            msg += ", ".join(QISKIT_OPERATION_MAP.keys())
+            raise ValueError(msg)
 
         if isinstance(mapped_operation, BasisState) and not self._first_operation:
             raise DeviceError("Operation {} cannot be used after other Operations have already been applied "
@@ -188,8 +193,6 @@ class QiskitDevice(Device):
         elif isinstance(mapped_operation, QiskitInstructions):
             op = mapped_operation  # type: QiskitInstructions
             op.apply(qregs=qregs, param=list(par), circuit=self._circuit)
-        else:
-            raise ValueError("The operation is not of an expected type. This is a software bug!")
 
     def _compile_and_execute(self):
         compile_backend = self.compile_backend if self.compile_backend is not None else self.backend  # type: BaseBackend

--- a/pennylane_qiskit/devices.py
+++ b/pennylane_qiskit/devices.py
@@ -307,8 +307,15 @@ class BasicAerQiskitDevice(QiskitDevice):
     Args:
         wires (int): The number of qubits of the device
         backend (str): the desired backend to run the code on. Default is :code:`qasm_simulator`.
+        initial_state (List[complex]): if using the backend that computes unitaries PennyLane cannot output
+                                        any expectation values, so we need to use one initial state. If not
+                                        given, the state |0> will be used.
 
     Keyword Args
+        name (str): The name of the circuit if it matters. Default 'circuit'.
+        compile_backend (BaseBackend): usually the configured backend is used against which will be compiled. If you which to
+                                separate this, e.g. if you want to simulate a device compliant circuit, you can
+                                choose a different backend.
         A range of :code:`backend_options` can be given in as kwargs that will be passed to the simulator.
         For details on the backends, please check out
             * `qasm_simulator <https://qiskit.org/documentation/autodoc/qiskit.providers.basicaer.qasm_simulator.html>`_
@@ -375,8 +382,15 @@ class AerQiskitDevice(QiskitDevice):
        wires (int): The number of qubits of the device
        backend (str): the desired backend to run the code on. Default is :code:`qasm_simulator`.
        noise_model (NoiseModel, optional): NoiseModel Object from qiskit.providers.aer.noise. Defaults to None
+       initial_state (List[complex]): if using the backend that computes unitaries PennyLane cannot output
+                                        any expectation values, so we need to use one initial state. If not
+                                        given, the state |0> will be used.
 
     Keyword Args
+        name (str): The name of the circuit if it matters. Default 'circuit'.
+        compile_backend (BaseBackend): usually the configured backend is used against which will be compiled. If you which to
+                                separate this, e.g. if you want to simulate a device compliant circuit, you can
+                                choose a different backend.
         A range of :code:`backend_options` can be given in as kwargs that will be passed to the simulator.
         For details on the backends, please check out
             * `qasm_simulator <https://qiskit.org/documentation/autodoc/qiskit.providers.aer.backends.qasm_simulator.html>`_

--- a/pennylane_qiskit/devices.py
+++ b/pennylane_qiskit/devices.py
@@ -188,9 +188,8 @@ class QiskitDevice(Device):
                 dag.apply_operation_back(instruction, qargs=qregs)
                 qc = dag_to_circuit(dag)
                 self._circuit = self._circuit + qc
-            else:
-                raise ValueError("Class not known and cannot be instantiated: ".format(type(instruction)))
-        elif isinstance(mapped_operation, QiskitInstructions):
+
+        if isinstance(mapped_operation, QiskitInstructions):
             op = mapped_operation  # type: QiskitInstructions
             op.apply(qregs=qregs, param=list(par), circuit=self._circuit)
 

--- a/tests/defaults.py
+++ b/tests/defaults.py
@@ -131,4 +131,4 @@ class BaseTest(unittest.TestCase):
         """
         Like assertTrue, but works with arrays. All the corresponding elements have to be True.
         """
-        return self.assertTrue(np.all(value))
+        return self.assertTrue(np.all(value), msg=msg)

--- a/tests/test_backend_options.py
+++ b/tests/test_backend_options.py
@@ -19,7 +19,7 @@ import logging as log
 from pennylane import numpy as np
 from pennylane.plugins import DefaultQubit
 
-from defaults import pennylane as qml, BaseTest, IBMQX_TOKEN
+from defaults import pennylane as qml, BaseTest
 from pennylane_qiskit import BasicAerQiskitDevice, IbmQQiskitDevice, AerQiskitDevice
 
 log.getLogger('defaults')
@@ -41,9 +41,9 @@ class BackendOptionsTest(BaseTest):
         if self.args.device == 'aer' or self.args.device == 'all':
             self.devices.append(AerQiskitDevice(wires=self.num_subsystems))
         if self.args.device == 'ibmq' or self.args.device == 'all':
-            if IBMQX_TOKEN is not None:
+            if self.args.ibmqx_token is not None:
                 self.devices.append(
-                    IbmQQiskitDevice(wires=self.num_subsystems, num_runs=8 * 1024, ibmqx_token=IBMQX_TOKEN))
+                    IbmQQiskitDevice(wires=self.num_subsystems, num_runs=8 * 1024, ibmqx_token=self.args.ibmqx_token))
             else:
                 log.warning("Skipping test of the IbmQQiskitDevice device because IBM login credentials could not be "
                             "found in the PennyLane configuration file.")

--- a/tests/test_backend_options.py
+++ b/tests/test_backend_options.py
@@ -1,0 +1,92 @@
+# Copyright 2018 Carsten Blank
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for :mod:`pennylane_qiskit` simple circuits.
+"""
+import logging as log
+import unittest
+
+import cmath
+import math
+from pennylane import numpy as np
+from pennylane.plugins import DefaultQubit
+from qiskit.providers.aer import noise
+from qiskit.providers.models import BackendProperties
+
+from defaults import pennylane as qml, BaseTest, IBMQX_TOKEN
+from pennylane_qiskit import BasicAerQiskitDevice, IbmQQiskitDevice, AerQiskitDevice
+
+log.getLogger('defaults')
+
+
+class BackendOptionsTest(BaseTest):
+    """test the BasisState operation.
+    """
+
+    num_subsystems = 4
+    devices = None
+
+    def setUp(self):
+        super().setUp()
+
+        self.devices = [DefaultQubit(wires=self.num_subsystems)]
+        if self.args.device == 'basicaer' or self.args.device == 'all':
+            self.devices.append(BasicAerQiskitDevice(wires=self.num_subsystems))
+        if self.args.device == 'aer' or self.args.device == 'all':
+            self.devices.append(AerQiskitDevice(wires=self.num_subsystems))
+        if self.args.device == 'ibmq' or self.args.device == 'all':
+            if IBMQX_TOKEN is not None:
+                self.devices.append(
+                    IbmQQiskitDevice(wires=self.num_subsystems, num_runs=8 * 1024, ibmqx_token=IBMQX_TOKEN))
+            else:
+                log.warning("Skipping test of the IbmQQiskitDevice device because IBM login credentials could not be "
+                            "found in the PennyLane configuration file.")
+
+    def test_basicaer_initial_unitary(self):
+        """Test BasisState with preparations on the whole system."""
+        if self.devices is None:
+            return
+        self.logTestName()
+
+        if self.args.device == 'basicaer' or self.args.device == 'all':
+            initial_unitary = np.array([
+                [1, 0, 0, 0],
+                [0, 0, 0, 1],
+                [0, 0, 1, 0],
+                [0, 1, 0, 0]
+            ])
+            dev = BasicAerQiskitDevice(wires=2, backend='unitary_simulator', initial_unitary=initial_unitary)
+            # dev = BasicAerQiskitDevice(wires=self.num_subsystems, backend='unitary_simulator')
+
+            @qml.qnode(dev)
+            def circuit():
+                return qml.expval.PauliZ(wires=[0]), qml.expval.PauliZ(wires=[1])
+
+            log.info("Outcome: %s", circuit())
+
+    def test_basicaer_chop_threshold(self):
+        """Test BasisState with preparations on the whole system."""
+        if self.devices is None:
+            return
+        self.logTestName()
+
+        if self.args.device == 'basicaer' or self.args.device == 'all':
+            dev = BasicAerQiskitDevice(wires=self.num_subsystems, chop_threshold=1e-1)
+
+            @qml.qnode(dev)
+            def circuit():
+                # TODO: rotation within the tolerance should be 0
+                return qml.expval.PauliZ(wires=[0]), qml.expval.PauliZ(wires=[1])
+
+            log.info("Outcome: %s", circuit())

--- a/tests/test_basis_state.py
+++ b/tests/test_basis_state.py
@@ -17,7 +17,7 @@ Unit tests for the :mod:`pennylane_qiskit` BasisState operation.
 
 import unittest
 import logging as log
-from defaults import pennylane as qml, BaseTest, IBMQX_TOKEN
+from defaults import pennylane as qml, BaseTest
 import pennylane
 from pennylane import numpy as np
 
@@ -43,9 +43,9 @@ class BasisStateTest(BaseTest):
         if self.args.device == 'aer' or self.args.device == 'all':
             self.devices.append(AerQiskitDevice(wires=self.num_subsystems))
         if self.args.device == 'ibmq' or self.args.device == 'all':
-            if IBMQX_TOKEN is not None:
+            if self.args.ibmqx_token is not None:
                 self.devices.append(
-                    IbmQQiskitDevice(wires=self.num_subsystems, num_runs=8 * 1024, ibmqx_token=IBMQX_TOKEN))
+                    IbmQQiskitDevice(wires=self.num_subsystems, num_runs=8 * 1024, ibmqx_token=self.args.ibmqx_token))
             else:
                 log.warning("Skipping test of the IbmQQiskitDevice device because IBM login credentials could not be "
                             "found in the PennyLane configuration file.")

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -34,6 +34,7 @@ class CompareWithDefaultQubitTest(BaseTest):
     """
     num_subsystems = 3  # This should be as large as the largest gate/observable, but we cannot know that before instantiating the device. We thus check later that all gates/observables fit.
     shots = 16 * 1024
+    ibmq_shots = 8 * 1024
     devices = None
 
     def setUp(self):
@@ -47,7 +48,7 @@ class CompareWithDefaultQubitTest(BaseTest):
         if self.args.device == 'ibmq' or self.args.device == 'all':
             if self.args.ibmqx_token is not None:
                 self.devices.append(
-                    IbmQQiskitDevice(wires=self.num_subsystems, shots=self.shots, ibmqx_token=self.args.ibmqx_token))
+                    IbmQQiskitDevice(wires=self.num_subsystems, shots=self.ibmq_shots, ibmqx_token=self.args.ibmqx_token))
             else:
                 log.warning("Skipping test of the IbmQQiskitDevice device because IBM login credentials "
                             "could not be found in the PennyLane configuration file.")

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -23,7 +23,7 @@ from pennylane.plugins.default_qubit import DefaultQubit
 
 import pennylane_qiskit
 import pennylane_qiskit.expval
-from defaults import pennylane as qml, BaseTest, IBMQX_TOKEN
+from defaults import pennylane as qml, BaseTest
 from pennylane_qiskit.devices import BasicAerQiskitDevice, IbmQQiskitDevice, AerQiskitDevice
 
 log.getLogger('defaults')

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -33,7 +33,7 @@ class CompareWithDefaultQubitTest(BaseTest):
     """Compares the behavior of the ProjectQ plugin devices with the default qubit device.
     """
     num_subsystems = 3  # This should be as large as the largest gate/observable, but we cannot know that before instantiating the device. We thus check later that all gates/observables fit.
-
+    shots = 16 * 1024
     devices = None
 
     def setUp(self):
@@ -41,13 +41,13 @@ class CompareWithDefaultQubitTest(BaseTest):
 
         self.devices = [DefaultQubit(wires=self.num_subsystems, shots=0)]
         if self.args.device == 'basicaer' or self.args.device == 'all':
-            self.devices.append(BasicAerQiskitDevice(wires=self.num_subsystems, shots=8 * 1024))
+            self.devices.append(BasicAerQiskitDevice(wires=self.num_subsystems, shots=self.shots))
         if self.args.device == 'aer' or self.args.device == 'all':
-            self.devices.append(AerQiskitDevice(wires=self.num_subsystems, shots=8 * 1024))
+            self.devices.append(AerQiskitDevice(wires=self.num_subsystems, shots=self.shots))
         if self.args.device == 'ibmq' or self.args.device == 'all':
             if self.args.ibmqx_token is not None:
                 self.devices.append(
-                    IbmQQiskitDevice(wires=self.num_subsystems, shots=8 * 1024, ibmqx_token=self.args.ibmqx_token))
+                    IbmQQiskitDevice(wires=self.num_subsystems, shots=self.shots, ibmqx_token=self.args.ibmqx_token))
             else:
                 log.warning("Skipping test of the IbmQQiskitDevice device because IBM login credentials "
                             "could not be found in the PennyLane configuration file.")

--- a/tests/test_device_initialization.py
+++ b/tests/test_device_initialization.py
@@ -55,6 +55,12 @@ class DeviceInitialization(BaseTest):
 
     def test_shots(self):
         if self.args.device == 'ibmq' or self.args.device == 'all':
+
+            if self.args.ibmqx_token is None:
+                log.warning("Skipping test of the IbmQQiskitDevice device because IBM login credentials could not be "
+                            "found in the PennyLane configuration file.")
+                return
+
             shots = 5
             dev1 = IbmQQiskitDevice(wires=self.num_subsystems, shots=shots, ibmqx_token=self.args.ibmqx_token)
             self.assertEqual(shots, dev1.shots)
@@ -328,6 +334,12 @@ class DeviceInitialization(BaseTest):
 
     def test_ibm_device(self):
         if self.args.device in ['ibmq', 'all']:
+
+            if self.args.ibmqx_token is None:
+                log.warning("Skipping test of the IbmQQiskitDevice device because IBM login credentials could not be "
+                            "found in the PennyLane configuration file.")
+                return
+
             import qiskit
             qiskit.IBMQ.enable_account(token=self.args.ibmqx_token)
             backends = qiskit.IBMQ.backends()

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -19,7 +19,7 @@ import logging as log
 import re
 import unittest
 
-from defaults import pennylane as qml, BaseTest, IBMQX_TOKEN
+from defaults import pennylane as qml, BaseTest
 from pennylane_qiskit.devices import BasicAerQiskitDevice, IbmQQiskitDevice, AerQiskitDevice
 
 log.getLogger('defaults')
@@ -41,7 +41,11 @@ class DocumentationTest(BaseTest):
         if self.args.device == 'aer' or self.args.device == 'all':
             self.devices.append(AerQiskitDevice(wires=self.num_subsystems))
         if self.args.device == 'ibmq' or self.args.device == 'all':
-            self.devices.append(IbmQQiskitDevice(wires=self.num_subsystems, num_runs=8 * 1024, ibmqx_token=IBMQX_TOKEN))
+            if self.args.ibmqx_token is not None:
+                self.devices.append(IbmQQiskitDevice(wires=self.num_subsystems, num_runs=8 * 1024, ibmqx_token=self.args.ibmqx_token))
+            else:
+                log.warning("Skipping test of the IbmQQiskitDevice device because IBM login credentials could not be "
+                            "found in the PennyLane configuration file.")
 
     def test_device_docstrings(self):
         for dev in self.devices:

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -182,6 +182,26 @@ class TestQVMBasic(BaseTest):
 
             self.assertAllAlmostEqual(res, expected, delta=5/np.sqrt(dev.shots))
 
+    def test_int_wires(self):
+        """Test that passing wires as int works for expval."""
+        theta = 0.432
+        phi = 0.123
+        for dev in self.devices:
+            dev.apply('RX', wires=[0], par=[theta])
+            dev.apply('RX', wires=[1], par=[phi])
+            dev.apply('CNOT', wires=[0, 1], par=[])
+
+            O = qml.expval.qubit.Identity
+            name = 'Identity'
+
+            dev._expval_queue = [O(wires=0, do_queue=False), O(wires=1, do_queue=False)]
+            res = dev.pre_expval()
+
+            res = np.array([dev.expval(name, 0, []), dev.expval(name, 1, [])])
+
+            # below are the analytic expectation values for this circuit (trace should always be 1)
+            self.assertAllAlmostEqual(res, np.array([1, 1]), delta=3/np.sqrt(dev.shots))
+
 
 if __name__ == '__main__':
     print('Testing PennyLane qiskit Plugin version ' + qml.version() + ', expectations.')

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -19,6 +19,7 @@ from pennylane import numpy as np
 
 from defaults import pennylane as qml, BaseTest
 from pennylane_qiskit import BasicAerQiskitDevice, AerQiskitDevice, IbmQQiskitDevice
+import unittest
 
 log.getLogger('defaults')
 
@@ -180,3 +181,14 @@ class TestQVMBasic(BaseTest):
             expected = np.array([ev1, ev2])
 
             self.assertAllAlmostEqual(res, expected, delta=5/np.sqrt(dev.shots))
+
+
+if __name__ == '__main__':
+    print('Testing PennyLane qiskit Plugin version ' + qml.version() + ', expectations.')
+    # run the tests in this file
+    suite = unittest.TestSuite()
+    for t in (TestQVMBasic,):
+        ttt = unittest.TestLoader().loadTestsFromTestCase(t)
+        suite.addTests(ttt)
+
+    unittest.TextTestRunner().run(suite)

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -17,7 +17,7 @@ Unit tests for :mod:`pennylane_qiskit` expectation values
 import logging as log
 from pennylane import numpy as np
 
-from defaults import pennylane as qml, BaseTest, IBMQX_TOKEN
+from defaults import pennylane as qml, BaseTest
 from pennylane_qiskit import BasicAerQiskitDevice, AerQiskitDevice, IbmQQiskitDevice
 
 log.getLogger('defaults')
@@ -41,9 +41,9 @@ class TestQVMBasic(BaseTest):
         if self.args.device == 'aer' or self.args.device == 'all':
             self.devices.append(AerQiskitDevice(wires=self.num_subsystems, shots=self.shots))
         if self.args.device == 'ibmq' or self.args.device == 'all':
-            if IBMQX_TOKEN is not None:
+            if self.args.ibmqx_token is not None:
                 self.devices.append(
-                    IbmQQiskitDevice(wires=self.num_subsystems, shots=self.ibmq_shots, ibmqx_token=IBMQX_TOKEN))
+                    IbmQQiskitDevice(wires=self.num_subsystems, shots=self.ibmq_shots, ibmqx_token=self.args.ibmqx_token))
             else:
                 log.warning("Skipping test of the IbmQQiskitDevice device because IBM login credentials could not be "
                             "found in the PennyLane configuration file.")

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -29,6 +29,7 @@ class TestQVMBasic(BaseTest):
 
     num_subsystems = 2
     shots = 16 * 1024
+    ibmq_shots = 8 * 1024
     devices = None
 
     def setUp(self):
@@ -42,7 +43,7 @@ class TestQVMBasic(BaseTest):
         if self.args.device == 'ibmq' or self.args.device == 'all':
             if IBMQX_TOKEN is not None:
                 self.devices.append(
-                    IbmQQiskitDevice(wires=self.num_subsystems, shots=self.shots, ibmqx_token=IBMQX_TOKEN))
+                    IbmQQiskitDevice(wires=self.num_subsystems, shots=self.ibmq_shots, ibmqx_token=IBMQX_TOKEN))
             else:
                 log.warning("Skipping test of the IbmQQiskitDevice device because IBM login credentials could not be "
                             "found in the PennyLane configuration file.")

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -1,0 +1,181 @@
+# Copyright 2018 Carsten Blank
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for :mod:`pennylane_qiskit` expectation values
+"""
+import logging as log
+from pennylane import numpy as np
+
+from defaults import pennylane as qml, BaseTest, IBMQX_TOKEN
+from pennylane_qiskit import BasicAerQiskitDevice, AerQiskitDevice, IbmQQiskitDevice
+
+log.getLogger('defaults')
+
+
+class TestQVMBasic(BaseTest):
+    """Unit tests for the QVM simulator."""
+    # pylint: disable=protected-access
+
+    num_subsystems = 2
+    shots = 16 * 1024
+    devices = None
+
+    def setUp(self):
+        super().setUp()
+
+        self.devices = []
+        if self.args.device == 'basicaer' or self.args.device == 'all':
+            self.devices.append(BasicAerQiskitDevice(wires=self.num_subsystems, shots=self.shots))
+        if self.args.device == 'aer' or self.args.device == 'all':
+            self.devices.append(AerQiskitDevice(wires=self.num_subsystems, shots=self.shots))
+        if self.args.device == 'ibmq' or self.args.device == 'all':
+            if IBMQX_TOKEN is not None:
+                self.devices.append(
+                    IbmQQiskitDevice(wires=self.num_subsystems, shots=self.shots, ibmqx_token=IBMQX_TOKEN))
+            else:
+                log.warning("Skipping test of the IbmQQiskitDevice device because IBM login credentials could not be "
+                            "found in the PennyLane configuration file.")
+
+    def test_identity_expectation(self):
+        """Test that identity expectation value (i.e. the trace) is 1"""
+        theta = 0.432
+        phi = 0.123
+        for dev in self.devices:
+            dev.apply('RX', wires=[0], par=[theta])
+            dev.apply('RX', wires=[1], par=[phi])
+            dev.apply('CNOT', wires=[0, 1], par=[])
+
+            O = qml.expval.qubit.Identity
+            name = 'Identity'
+
+            dev._expval_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
+            res = dev.pre_expval()
+
+            res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
+
+            # below are the analytic expectation values for this circuit (trace should always be 1)
+            self.assertAllAlmostEqual(res, np.array([1, 1]), delta=3/np.sqrt(dev.shots))
+
+    def test_pauliz_expectation(self):
+        """Test that PauliZ expectation value is correct"""
+        theta = 0.432
+        phi = 0.123
+
+        for dev in self.devices:
+            dev.apply('RX', wires=[0], par=[theta])
+            dev.apply('RX', wires=[1], par=[phi])
+            dev.apply('CNOT', wires=[0, 1], par=[])
+
+            O = qml.expval.PauliZ
+            name = 'PauliZ'
+
+            dev._expval_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
+            res = dev.pre_expval()
+
+            res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
+
+            # below are the analytic expectation values for this circuit
+            self.assertAllAlmostEqual(res, np.array([np.cos(theta), np.cos(theta)*np.cos(phi)]), delta=3/np.sqrt(dev.shots))
+
+    def test_paulix_expectation(self):
+        """Test that PauliX expectation value is correct"""
+        theta = 0.432
+        phi = 0.123
+
+        for dev in self.devices:
+            dev.apply('RY', wires=[0], par=[theta])
+            dev.apply('RY', wires=[1], par=[phi])
+            dev.apply('CNOT', wires=[0, 1], par=[])
+
+            O = qml.expval.PauliX
+            name = 'PauliX'
+
+            dev._expval_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
+            dev.pre_expval()
+
+            res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
+            # below are the analytic expectation values for this circuit
+            self.assertAllAlmostEqual(res, np.array([np.sin(theta)*np.sin(phi), np.sin(phi)]), delta=3/np.sqrt(dev.shots))
+
+    def test_pauliy_expectation(self):
+        """Test that PauliY expectation value is correct"""
+        theta = 0.432
+        phi = 0.123
+
+        for dev in self.devices:
+            dev.apply('RX', wires=[0], par=[theta])
+            dev.apply('RX', wires=[1], par=[phi])
+            dev.apply('CNOT', wires=[0, 1], par=[])
+
+            O = qml.expval.PauliY
+            name = 'PauliY'
+
+            dev._expval_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
+            dev.pre_expval()
+
+            # below are the analytic expectation values for this circuit
+            res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
+            self.assertAllAlmostEqual(res, np.array([0, -np.cos(theta)*np.sin(phi)]), delta=3/np.sqrt(dev.shots))
+
+    def test_hadamard_expectation(self):
+        """Test that Hadamard expectation value is correct"""
+        theta = 0.432
+        phi = 0.123
+
+        for dev in self.devices:
+            dev.apply('RY', wires=[0], par=[theta])
+            dev.apply('RY', wires=[1], par=[phi])
+            dev.apply('CNOT', wires=[0, 1], par=[])
+
+            O = qml.expval.Hadamard
+            name = 'Hadamard'
+
+            dev._expval_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
+            dev.pre_expval()
+
+            res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
+            # below are the analytic expectation values for this circuit
+            expected = np.array([np.sin(theta)*np.sin(phi)+np.cos(theta), np.cos(theta)*np.cos(phi)+np.sin(phi)])/np.sqrt(2)
+            self.assertAllAlmostEqual(res, expected, delta=3/np.sqrt(dev.shots))
+
+    def test_hermitian_expectation(self):
+        """Test that arbitrary Hermitian expectation values are correct"""
+        theta = 0.432
+        phi = 0.123
+        H = np.array([[1.02789352, 1.61296440 - 0.3498192j],
+                      [1.61296440 + 0.3498192j, 1.23920938 + 0j]])
+
+        for dev in self.devices:
+            dev.apply('RY', wires=[0], par=[theta])
+            dev.apply('RY', wires=[1], par=[phi])
+            dev.apply('CNOT', wires=[0, 1], par=[])
+
+            O = qml.expval.qubit.Hermitian
+            name = 'Hermitian'
+
+            dev._expval_queue = [O(H, wires=[0], do_queue=False), O(H, wires=[1], do_queue=False)]
+            dev.pre_expval()
+
+            res = np.array([dev.expval(name, [0], [H]), dev.expval(name, [1], [H])])
+
+            # below are the analytic expectation values for this circuit with arbitrary
+            # Hermitian observable H
+            a = H[0, 0]
+            re_b = H[0, 1].real
+            d = H[1, 1]
+            ev1 = ((a-d)*np.cos(theta)+2*re_b*np.sin(theta)*np.sin(phi)+a+d)/2
+            ev2 = ((a-d)*np.cos(theta)*np.cos(phi)+2*re_b*np.sin(phi)+a+d)/2
+            expected = np.array([ev1, ev2])
+
+            self.assertAllAlmostEqual(res, expected, delta=5/np.sqrt(dev.shots))

--- a/tests/test_simple_circuits.py
+++ b/tests/test_simple_circuits.py
@@ -36,6 +36,7 @@ class SimpleCircuitsTest(BaseTest):
 
     num_subsystems = 4
     shots = 16 * 1024
+    ibmq_shots = 8 * 1024
     devices = None
 
     def setUp(self):
@@ -49,7 +50,7 @@ class SimpleCircuitsTest(BaseTest):
         if self.args.device == 'ibmq' or self.args.device == 'all':
             if IBMQX_TOKEN is not None:
                 self.devices.append(
-                    IbmQQiskitDevice(wires=self.num_subsystems, shots=self.shots, ibmqx_token=IBMQX_TOKEN))
+                    IbmQQiskitDevice(wires=self.num_subsystems, shots=self.ibmq_shots, ibmqx_token=IBMQX_TOKEN))
             else:
                 log.warning("Skipping test of the IbmQQiskitDevice device because IBM login credentials could not be "
                             "found in the PennyLane configuration file.")

--- a/tests/test_simple_circuits.py
+++ b/tests/test_simple_circuits.py
@@ -35,6 +35,7 @@ class SimpleCircuitsTest(BaseTest):
     """
 
     num_subsystems = 4
+    shots = 16 * 1024
     devices = None
 
     def setUp(self):
@@ -42,13 +43,13 @@ class SimpleCircuitsTest(BaseTest):
 
         self.devices = [DefaultQubit(wires=self.num_subsystems)]
         if self.args.device == 'basicaer' or self.args.device == 'all':
-            self.devices.append(BasicAerQiskitDevice(wires=self.num_subsystems))
+            self.devices.append(BasicAerQiskitDevice(wires=self.num_subsystems, shots=self.shots))
         if self.args.device == 'aer' or self.args.device == 'all':
-            self.devices.append(AerQiskitDevice(wires=self.num_subsystems))
+            self.devices.append(AerQiskitDevice(wires=self.num_subsystems, shots=self.shots))
         if self.args.device == 'ibmq' or self.args.device == 'all':
             if IBMQX_TOKEN is not None:
                 self.devices.append(
-                    IbmQQiskitDevice(wires=self.num_subsystems, num_runs=8 * 1024, ibmqx_token=IBMQX_TOKEN))
+                    IbmQQiskitDevice(wires=self.num_subsystems, shots=self.shots, ibmqx_token=IBMQX_TOKEN))
             else:
                 log.warning("Skipping test of the IbmQQiskitDevice device because IBM login credentials could not be "
                             "found in the PennyLane configuration file.")

--- a/tests/test_unsupported_operations.py
+++ b/tests/test_unsupported_operations.py
@@ -20,7 +20,7 @@ import unittest
 
 import pennylane
 
-from defaults import pennylane as qml, BaseTest, IBMQX_TOKEN
+from defaults import pennylane as qml, BaseTest
 from pennylane_qiskit.devices import BasicAerQiskitDevice, IbmQQiskitDevice,  \
     AerQiskitDevice
 
@@ -43,9 +43,9 @@ class UnsupportedOperationTest(BaseTest):
         if self.args.device == 'aer' or self.args.device == 'all':
             self.devices.append(AerQiskitDevice(wires=self.num_subsystems))
         if self.args.device == 'ibmq' or self.args.device == 'all':
-            if IBMQX_TOKEN is not None:
+            if self.args.ibmqx_token is not None:
                 self.devices.append(
-                    IbmQQiskitDevice(wires=self.num_subsystems, num_runs=8 * 1024, ibmqx_token=IBMQX_TOKEN))
+                    IbmQQiskitDevice(wires=self.num_subsystems, num_runs=8 * 1024, ibmqx_token=self.args.ibmqx_token))
             else:
                 log.warning(
                     "Skipping test of the IbmQQiskitDevice device because IBM login credentials could not be found in the PennyLane configuration file.")

--- a/tests/test_unsupported_operations.py
+++ b/tests/test_unsupported_operations.py
@@ -63,6 +63,9 @@ class UnsupportedOperationTest(BaseTest):
 
             self.assertRaises(pennylane._device.DeviceError, circuit)
 
+        for device in self.devices:
+            self.assertRaises(ValueError, device.apply, 'RXY', wires=[0], par=None)
+
     def test_unsupported_expectation(self):
         if self.devices is None:
             return


### PR DESCRIPTION
This PR will address issues #8 and #28 . Albeit having a weird branch naming (it got a little hectic today while transferring the project to Xanadu!) this is a major change in features and code!

In more detail:
* #8 has been added especially in the `devices.QiskitDevice#_compile_and_execute` function where the known backends are listed and the `backend_options` are passed in (as with the noise model). The tests are found in `test_backend_options.py` and they caused some head-ache for me until I finally realized what it was I want to test. The tests `test_basicaer_initial_unitary` and `test_basicaer_chop_threshold` are basically useless but helped me to root out bugs that the current tests didn't catch.

* #23 Now this one was basically inspired by the `pennylane-forest` plugin and @josh146 explanations. I added the unit tests from `pennylane-forest` too. A lot of adjustments were necessary and another bug found in the (rather ugly) `qiskitops.QubitUnitary`. I added the documentation too.

This should be reviewed as soon as CI as up and running again! 

@josh146  can you review this maybe? 