### PR TITLE
Bumped master to version 0.0.9

### DIFF
--- a/pennylane_qiskit/_version.py
+++ b/pennylane_qiskit/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.0.8'
+__version__ = '0.0.9'


### PR DESCRIPTION
It is a good practice to keep the master ahead of the last release so I am bumping the version to 0.0.9. 