### PR TITLE
Update tests, version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,16 @@
-# Release 0.6.0-dev
+# Release 0.6.0
 
 ### New features since last release
 
-### Breaking changes
-
-### Improvements
-
-### Documentation
-
-### Bug fixes
+* All Qiskit devices now support tensor observables using the
+  `return expval(qml.PauliZ(0) @ qml.Hermitian(A, [1, 2]))`
+  syntax introduced in PennyLane v0.6.
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Josh Izaac
 
 ---
 

--- a/pennylane_qiskit/_version.py
+++ b/pennylane_qiskit/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.6.0-dev"
+__version__ = "0.6.0"

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -119,8 +119,8 @@ class QiskitDevice(Device, abc.ABC):
             Default value is ``True``.
     """
     name = "Qiskit PennyLane plugin"
-    pennylane_requires = ">=0.5.0"
-    version = "0.5.0"
+    pennylane_requires = ">=0.6.0"
+    version = "0.6.0"
     plugin_version = __version__
     author = "Xanadu"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 qiskit>=0.12
-PennyLane>=0.5.0
+PennyLane>=0.6.0
 numpy

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("README.rst", "r") as fh:
 
 requirements = [
     "qiskit>=0.12",
-    "pennylane>=0.5.0",
+    "pennylane>=0.6.0",
     "numpy"
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 import pytest
 import numpy as np
 
@@ -54,6 +53,3 @@ def device(request, backend, shots, analytic):
         return request.param(wires=n, backend=backend, shots=shots, analytic=analytic)
 
     return _device
-
-
-Tensor = namedtuple("Tensor", ["name", "wires", "parameters", "return_type"])

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 import pennylane as qml
 
-from conftest import U, U2, A, Tensor
+from conftest import U, U2, A
 
 
 np.random.seed(42)
@@ -181,7 +181,7 @@ class TestTensorExpval:
         dev.apply("CNOT", wires=[1, 2], par=[])
 
         dev._obs_queue = [
-            Tensor(["PauliX", "PauliY"], [[0], [2]], [[], []], qml.operation.Expectation)
+            qml.PauliX(0, do_queue=False) @ qml.PauliY(2, do_queue=False)
         ]
         dev.pre_measure()
 
@@ -200,7 +200,7 @@ class TestTensorExpval:
         dev.apply("CNOT", wires=[1, 2], par=[])
 
         dev._obs_queue = [
-            Tensor(["PauliZ", "Identity", "PauliZ"], [[0], [1], [2]], [[], [], []], qml.operation.Expectation)
+            qml.PauliZ(0, do_queue=False) @ qml.Identity(1, do_queue=False) @ qml.PauliZ(2, do_queue=False)
         ]
 
         dev.post_apply()
@@ -221,7 +221,7 @@ class TestTensorExpval:
         dev.apply("CNOT", wires=[1, 2], par=[])
 
         dev._obs_queue = [
-            Tensor(["PauliZ", "Hadamard", "PauliY"], [[0], [1], [2]], [[], [], []], qml.operation.Expectation)
+            qml.PauliZ(0, do_queue=False) @ qml.Hadamard(1, do_queue=False) @ qml.PauliY(2, do_queue=False)
         ]
         dev.pre_measure()
 
@@ -248,7 +248,9 @@ class TestTensorExpval:
             ]
         )
 
-        dev._obs_queue = [Tensor(["PauliZ", "Hermitian"], [[0], [1, 2]], [[], [A]], qml.operation.Expectation)]
+        dev._obs_queue = [
+            qml.PauliZ(0, do_queue=False) @ qml.Hermitian(A, [1, 2], do_queue=False)
+        ]
         dev.pre_measure()
 
         res = dev.expval(["PauliZ", "Hermitian"], [[0], [1, 2]], [[], [A]])
@@ -283,7 +285,7 @@ class TestTensorExpval:
         )
 
         dev._obs_queue = [
-            Tensor(["Hermitian", "Hermitian"], [[0], [1, 2]], [[A1], [A2]], qml.operation.Expectation)
+            qml.Hermitian(A1, 0, do_queue=False) @ qml.Hermitian(A2, [1, 2], do_queue=False)
         ]
         dev.pre_measure()
 
@@ -313,7 +315,7 @@ class TestTensorExpval:
         dev.apply("RY", wires=[1], par=[phi])
         dev.apply("CNOT", wires=[0, 1], par=[])
 
-        dev._obs_queue = [Tensor(["Hermitian", "Identity"], [[0], [1]], [[A], []], qml.operation.Expectation)]
+        dev._obs_queue = [qml.Hermitian(A, 0, do_queue=False) @ qml.Identity(1, do_queue=False)]
         dev.pre_measure()
 
         res = dev.expval(["Hermitian", "Identity"], [[0], [1]], [[A], []])

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -5,7 +5,7 @@ import pennylane as qml
 
 from pennylane_qiskit import AerDevice, BasicAerDevice
 
-from conftest import U, U2, A, Tensor
+from conftest import U, U2, A
 
 
 np.random.seed(42)
@@ -134,11 +134,11 @@ class TestTensorSample:
         dev.apply("CNOT", wires=[1, 2], par=[])
 
         dev._obs_queue = [
-            Tensor(["PauliX", "PauliY"], [[0], [2]], [[], []], qml.operation.Sample)
+            qml.PauliX(0, do_queue=False) @ qml.PauliY(2, do_queue=False)
         ]
 
-        # for idx in range(len(dev._obs_queue)):
-        #     dev._obs_queue[idx].return_type = qml.operation.Sample
+        for idx in range(len(dev._obs_queue)):
+            dev._obs_queue[idx].return_type = qml.operation.Sample
 
         res = dev.pre_measure()
 
@@ -172,11 +172,11 @@ class TestTensorSample:
         dev.apply("CNOT", wires=[1, 2], par=[])
 
         dev._obs_queue = [
-            Tensor(["PauliZ", "Hadamard", "PauliY"], [[0], [1], [2]], [[], [], []], qml.operation.Sample)
+            qml.PauliZ(0, do_queue=False) @ qml.Hadamard(1, do_queue=False) @ qml.PauliY(2, do_queue=False)
         ]
 
-        # for idx in range(len(dev._obs_queue)):
-        #     dev._obs_queue[idx].return_type = qml.operation.Sample
+        for idx in range(len(dev._obs_queue)):
+            dev._obs_queue[idx].return_type = qml.operation.Sample
 
         res = dev.pre_measure()
 
@@ -216,10 +216,12 @@ class TestTensorSample:
             ]
         )
 
-        dev._obs_queue = [Tensor(["PauliZ", "Hermitian"], [[0], [1, 2]], [[], [A]], qml.operation.Sample)]
+        dev._obs_queue = [
+            qml.PauliZ(0, do_queue=False) @ qml.Hermitian(A, [1, 2], do_queue=False)
+        ]
 
-        # for idx in range(len(dev._obs_queue)):
-        #     dev._obs_queue[idx].return_type = qml.operation.Sample
+        for idx in range(len(dev._obs_queue)):
+            dev._obs_queue[idx].return_type = qml.operation.Sample
 
         res = dev.pre_measure()
 

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -140,7 +140,7 @@ class TestTensorSample:
         for idx in range(len(dev._obs_queue)):
             dev._obs_queue[idx].return_type = qml.operation.Sample
 
-        res = dev.pre_measure()
+        dev.pre_measure()
 
         s1 = dev.sample(["PauliX", "PauliY"], [[0], [2]], [[], [], []])
 
@@ -178,7 +178,7 @@ class TestTensorSample:
         for idx in range(len(dev._obs_queue)):
             dev._obs_queue[idx].return_type = qml.operation.Sample
 
-        res = dev.pre_measure()
+        dev.pre_measure()
 
         s1 = dev.sample(["PauliZ", "Hadamard", "PauliY"], [[0], [1], [2]], [[], [], []])
 
@@ -223,7 +223,7 @@ class TestTensorSample:
         for idx in range(len(dev._obs_queue)):
             dev._obs_queue[idx].return_type = qml.operation.Sample
 
-        res = dev.pre_measure()
+        dev.pre_measure()
 
         s1 = dev.sample(["PauliZ", "Hermitian"], [[0], [1, 2]], [[], [A]])
 

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -5,7 +5,7 @@ import pennylane as qml
 
 from pennylane_qiskit import AerDevice, BasicAerDevice
 
-from conftest import U, U2, A, Tensor
+from conftest import U, U2, A
 
 
 np.random.seed(42)
@@ -76,7 +76,7 @@ class TestTensorVar:
         dev.apply("CNOT", wires=[1, 2], par=[])
 
         dev._obs_queue = [
-            Tensor(["PauliX", "PauliY"], [[0], [2]], [[], []], qml.operation.Variance)
+            qml.PauliX(0, do_queue=False) @ qml.PauliY(2, do_queue=False)
         ]
         dev.pre_measure()
 
@@ -103,7 +103,7 @@ class TestTensorVar:
         dev.apply("CNOT", wires=[1, 2], par=[])
 
         dev._obs_queue = [
-            Tensor(["PauliZ", "Hadamard", "PauliY"], [[0], [1], [2]], [[], [], []], qml.operation.Variance)
+            qml.PauliZ(0, do_queue=False) @ qml.Hadamard(1, do_queue=False) @ qml.PauliY(2, do_queue=False)
         ]
         dev.pre_measure()
 
@@ -136,9 +136,8 @@ class TestTensorVar:
             ]
         )
 
-        dev._obs_queue = [Tensor(["PauliZ", "Hermitian"], [[0], [1, 2]], [[], [A]], qml.operation.Variance)]
+        dev._obs_queue = [qml.PauliZ(0, do_queue=False) @ qml.Hermitian(A, [1, 2], do_queue=False)]
         dev.pre_measure()
-
         res = dev.var(["PauliZ", "Hermitian"], [[0], [1, 2]], [[], [A]])
 
         expected = (


### PR DESCRIPTION
*Description of changes:*

* All Qiskit devices now support tensor observables using the
  `return expval(qml.PauliZ(0) @ qml.Hermitian(A, [1, 2]))`
  syntax introduced in PennyLane v0.6.

* Verified to work with Qiskit version 0.13

* Version bump