### PR TITLE
Add pl load integration tests

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -135,7 +135,7 @@ class TestLoadIntegration:
     def test_load_from_qasm_string(self):
         """Test that quantum circuits can be loaded from a qasm string."""
 
-        dev = qml.device('qiskit.aer', backend='statevector_simulator', shots=1000, wires=2)
+        dev = qml.device('default.qubit', wires=2)
 
         @qml.qnode(dev)
         def loaded_quantum_circuit():


### PR DESCRIPTION
Adding integration tests for the PennyLane-Qiskit converter. These tests use the ``load`` functions from ``pennylane/__init__.py``.