### PR TITLE
Update qiskit noise examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,9 +152,10 @@ You can instantiate a noise model and apply it to the device by calling
     import qiskit
     from qiskit.providers.aer.noise.device import basic_device_noise_model
 
-    qiskit.IBMQ.load_accounts()
-    ibmqx4 = qiskit.IBMQ.get_backend('ibmqx4')
-    device_properties = ibmqx4.properties()
+    qiskit.IBMQ.load_account()
+    provider = qiskit.IBMQ.get_provider(group='open')
+    ibmq16 = provider.get_backend('ibmq_16_melbourne')
+    device_properties = ibmq16.properties()
 
     noise_model = basic_device_noise_model(device_properties)
 

--- a/README.rst
+++ b/README.rst
@@ -154,8 +154,8 @@ You can instantiate a noise model and apply it to the device by calling
 
     qiskit.IBMQ.load_account()
     provider = qiskit.IBMQ.get_provider(group='open')
-    ibmq16 = provider.get_backend('ibmq_16_melbourne')
-    device_properties = ibmq16.properties()
+    ibmq_16_melbourne = provider.get_backend('ibmq_16_melbourne')
+    device_properties = ibmq_16_melbourne.properties()
 
     noise_model = basic_device_noise_model(device_properties)
 
@@ -173,7 +173,7 @@ You can choose between different backends - either simulators or real hardware.
 .. code-block:: python
 
     import pennylane as qml
-    dev = qml.device('qiskit.ibmq', wires=2, backend='ibmqx4')
+    dev = qml.device('qiskit.ibmq', wires=2, backend='ibmq_16_melbourne')
 
 By default, the ``qiskit.ibmq`` device will attempt to use an already active or stored
 IBM Q account. If none are available, you may also directly pass your IBM Q API token,


### PR DESCRIPTION
Update the example on noise models in the ``README.rst`` such that no deprecated methods and backends are used anymore.