### PR TITLE
Set analytic=False as default

### DIFF
--- a/pennylane_qiskit/aer.py
+++ b/pennylane_qiskit/aer.py
@@ -63,7 +63,7 @@ class AerDevice(QiskitDevice):
             to simulate a device compliant circuit, you can specify a backend here.
         analytic (bool): For statevector backends, determines if the
             expectation values and variances are to be computed analytically.
-            Default value is ``True``.
+            Default value is ``False``.
         noise_model (NoiseModel): NoiseModel Object from ``qiskit.providers.aer.noise``
     """
 

--- a/pennylane_qiskit/basic_aer.py
+++ b/pennylane_qiskit/basic_aer.py
@@ -63,7 +63,7 @@ class BasicAerDevice(QiskitDevice):
             to simulate a device compliant circuit, you can specify a backend here.
         analytic (bool): For statevector backends, determines if the
             expectation values and variances are to be computed analytically.
-            Default value is ``True``.
+            Default value is ``False``.
     """
 
     short_name = "qiskit.basicaer"

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -114,7 +114,7 @@ class QiskitDevice(Device, abc.ABC):
             to simulate a device compliant circuit, you can specify a backend here.
         analytic (bool): For statevector backends, determines if the
             expectation values and variances are to be computed analytically.
-            Default value is ``True``.
+            Default value is ``False``.
     """
     name = "Qiskit PennyLane plugin"
     pennylane_requires = ">=0.8.0"
@@ -140,7 +140,7 @@ class QiskitDevice(Device, abc.ABC):
     def __init__(self, wires, provider, backend, shots=1024, **kwargs):
         super().__init__(wires=wires, shots=shots)
 
-        self.analytic = kwargs.pop("analytic", True)
+        self.analytic = kwargs.pop("analytic", False)
 
         if "verbose" not in kwargs:
             kwargs["verbose"] = False

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -45,7 +45,7 @@ class TestAnalyticWarningHWSimulator:
         """Tests that a warning is raised if the analytic attribute is true on
             hardware simulators when calculating the expectation"""
 
-        dev = qml.device("qiskit.basicaer", backend=hardware_backend, wires=2)
+        dev = qml.device("qiskit.basicaer", backend=hardware_backend, wires=2, analytic=True)
 
         @qml.qnode(dev)
         def circuit():
@@ -66,7 +66,7 @@ class TestAnalyticWarningHWSimulator:
         """Tests that no warning is raised if the analytic attribute is true on
             statevector simulators when calculating the expectation"""
 
-        dev = qml.device("qiskit.basicaer", backend=statevector_backend, wires=2)
+        dev = qml.device("qiskit.basicaer", backend=statevector_backend, wires=2, analytic=True)
 
         @qml.qnode(dev)
         def circuit():
@@ -82,7 +82,7 @@ class TestAnalyticWarningHWSimulator:
         """Tests that a warning is raised if the analytic attribute is true on
             hardware simulators when calculating the variance"""
 
-        dev = qml.device("qiskit.basicaer", backend=hardware_backend, wires=2)
+        dev = qml.device("qiskit.basicaer", backend=hardware_backend, wires=2, analytic=True)
 
         @qml.qnode(dev)
         def circuit():
@@ -103,7 +103,7 @@ class TestAnalyticWarningHWSimulator:
         """Tests that no warning is raised if the analytic attribute is true on
             statevector simulators when calculating the variance"""
 
-        dev = qml.device("qiskit.basicaer", backend=statevector_backend, wires=2)
+        dev = qml.device("qiskit.basicaer", backend=statevector_backend, wires=2, analytic=True)
 
         @qml.qnode(dev)
         def circuit():


### PR DESCRIPTION
Changing the default value of ``analytic`` since by default warnings are raised when using hardware simulators.