### PR TITLE
Skipping test for Terra v0.9-v0.10 (and keeping these qiskit versions)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,13 @@
-import pytest
-import numpy as np
-
-import pennylane as qml
-from pennylane_qiskit import AerDevice, BasicAerDevice
-
 import contextlib
 import io
 
+import numpy as np
+import pennylane as qml
+import pytest
+from packaging import version
+from qiskit import __version__
+
+from pennylane_qiskit import AerDevice, BasicAerDevice
 
 np.random.seed(42)
 
@@ -51,6 +52,16 @@ def skip_unitary(backend):
 def run_only_for_unitary(backend):
     if backend != "unitary_simulator":
         pytest.skip("This test only supports the unitary simulator.")
+
+@pytest.fixture
+def run_only_for_qiskit_terra_v0_11_and_above():
+    if version.parse(__version__) < version.parse("0.11.0"):
+        pytest.skip("This test is only ran for Qiskit Terra version 0.11.0 and above.")
+
+@pytest.fixture
+def run_only_for_qiskit_terra_version_below_v0_11():
+    if version.parse(__version__) >=  version.parse("0.11.0"):
+        pytest.skip("This test is only ran for Qiskit Terra version that is below 0.11.0.")
 
 @pytest.fixture(params=state_backends + hw_backends)
 def backend(request):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -2,7 +2,7 @@ import math
 import sys
 
 import pytest
-from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, __version__
 from qiskit import extensions as ex
 from qiskit.circuit import Parameter
 from qiskit.exceptions import QiskitError
@@ -540,7 +540,8 @@ class TestConverter:
             with recorder:
                 quantum_circuit(params={theta: angle})
 
-    def test_quantum_circuit_error_by_calling_wrong_parameters(self, recorder):
+    @pytest.mark.usefixtures("run_only_for_qiskit_terra_v0_11_and_above")
+    def test_quantum_circuit_error_by_calling_wrong_parameters_above_terra_v0_11(self, recorder):
         """Tests that the load method for a QuantumCircuit raises a TypeError,
         if the wrong type of arguments were passed."""
 
@@ -552,6 +553,22 @@ class TestConverter:
         quantum_circuit = load(qc)
 
         with pytest.raises(ValueError, match="could not convert string to float: '{}'".format(angle)):
+            with recorder:
+                quantum_circuit()
+
+    @pytest.mark.usefixtures("run_only_for_qiskit_terra_version_below_v0_11")
+    def test_quantum_circuit_error_by_calling_wrong_parameters_below_terra_v0_11(self, recorder):
+        """Tests that the load method for a QuantumCircuit raises a TypeError,
+        if the wrong type of arguments were passed."""
+
+        angle = 'some_string_instead_of_an_angle'
+
+        qc = QuantumCircuit(3, 1)
+        qc.rz(angle, [0])
+
+        quantum_circuit = load(qc)
+
+        with pytest.raises(TypeError, match="can't convert expression to float"):
             with recorder:
                 quantum_circuit()
 


### PR DESCRIPTION
**Context:**
Currently, if sticking with `qiskit==0.12` as per the `requirements.txt`, we get the following error for the following test case:
```
___________________________________________________________________ TestConverter.test_quantum_circuit_error_by_calling_wrong_parameters ___________________________________________________________________
tests/test_converter.py:556: in test_quantum_circuit_error_by_calling_wrong_parameters
    quantum_circuit()
pennylane_qiskit/converter.py:164: in _function
    execute_supported_operation(inv_map[instruction_name], op[0].params, operation_wires)
pennylane_qiskit/converter.py:117: in execute_supported_operation
    float_params = [float(param) for param in parameters]
pennylane_qiskit/converter.py:117: in <listcomp>
    float_params = [float(param) for param in parameters]
../../anaconda3/envs/pl_qiskit/lib/python3.7/site-packages/sympy/core/expr.py:325: in __float__
    raise TypeError("can't convert expression to float")
E   TypeError: can't convert expression to float
=============================================================================== 1 failed, 882 passed, 232 skipped in 25.49s ================================================================================
Makefile:50: recipe for target 'test' failed
make: *** [test] Error 1
```
**Description of the Change:**
This PR adds conditional test cases for the `test_quantum_circuit_error_by_calling_wrong_parameters` test case, should support for `qiskit==0.12` and `qiskit==0.13` persist. With these versions, a `sympy` error is outputted, therefore the error message has been changed accordingly. For `qiskit>=0.14`, the current error message was kept.

The following version were considered (including the increment with `qiskit==0.13.0` and `qiskit-terra==0.10.0`
```
PennyLane-qiskit==0.7.1
qiskit==0.12.0
qiskit-aer==0.3.0
qiskit-aqua==0.6.0
qiskit-ibmq-provider==0.3.2
qiskit-ignis==0.2.0
qiskit-terra==0.9.0
```

The specific gate used in the test is the following one from Qiskit Terra:
https://github.com/Qiskit/qiskit-terra/blob/master/qiskit/extensions/standard/rz.py

Since it is to some extent problematic to query the specific version of the current qiskit installation and the file in question is in the Terra project, hence the ``qiskit.__version__`` function was chosen to be used.

**Benefits:**
Earlier versions of Qiskit are still supported (`qiskit>=0.12.0`).

**Possible Drawbacks:**
Certain qiskit `v0.14.0` improvements would not be guaranteed:
* The `initialize()` method would not be natively unsupported by Qiskit `unitary_simulator`, although checks are included in PL-Qiskit
* The old IBMQ syntax would not be deprecated natively by Qiskit for `v0.12` and `v0.13` (that has also been deprecated in PL-Qiskit)

**TODO**: should this PR be closed, the `requirements.txt` and `setup.py` will have to be modified having `qiskit>=0.14` in [#66].

**Related GitHub Issues:**
N/A