### PR TITLE
Fixed bug in gradients of loaded qiskit circuits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Fixed a bug where gradient computations always returned 0 when
   loading a parametrized Qiskit circuit as a PennyLane template.
+  [(#71)](https://github.com/XanaduAI/pennylane-qiskit/pull/71)
 
 ### Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@
 
 ### Bug fixes
 
+* Fixed a bug where gradient computations always returned 0 when
+  loading a parametrized Qiskit circuit as a PennyLane template.
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Josh Izaac
 
 ---
 

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -37,20 +37,20 @@ from pennylane_qiskit.qiskit_device import QISKIT_OPERATION_MAP
 inv_map = {v.__name__: k for k, v in QISKIT_OPERATION_MAP.items()}
 
 
-def _check_parameter_bound(param: Parameter, var_ref_map: Dict[Parameter, qml.variable.VariableRef]):
+def _check_parameter_bound(param: Parameter, var_ref_map: Dict[Parameter, qml.variable.Variable]):
     """Utility function determining if a certain parameter in a QuantumCircuit has
     been bound.
 
     Args:
         param (qiskit.circuit.Parameter): the parameter to be checked
-        var_ref_map (dict[qiskit.circuit.Parameter, pennylane.variable.VariableRef]):
+        var_ref_map (dict[qiskit.circuit.Parameter, pennylane.variable.Variable]):
             a dictionary mapping qiskit parameters to PennyLane variables
     """
     if isinstance(param, Parameter) and param not in var_ref_map:
         raise ValueError("The parameter {} was not bound correctly.".format(param))
 
 
-def _extract_variable_refs(params: Dict[Parameter, Any]) -> Dict[Parameter, qml.variable.VariableRef]:
+def _extract_variable_refs(params: Dict[Parameter, Any]) -> Dict[Parameter, qml.variable.Variable]:
     """Iterate through the parameter mapping to be bound to the circuit,
     and return a dictionary containing the differentiable parameters.
 
@@ -58,14 +58,14 @@ def _extract_variable_refs(params: Dict[Parameter, Any]) -> Dict[Parameter, qml.
         params (dict): dictionary of the parameters in the circuit to their corresponding values
 
     Returns:
-        dict[qiskit.circuit.Parameter, pennylane.variable.VariableRef]: a dictionary mapping
+        dict[qiskit.circuit.Parameter, pennylane.variable.Variable]: a dictionary mapping
             qiskit parameters to PennyLane variables
     """
-    # map qiskit parameters to PennyLane differentiable VariableRefs.
+    # map qiskit parameters to PennyLane differentiable Variables.
     if params is None:
         return {}
 
-    return {k: v for k, v in params.items() if isinstance(v, qml.variable.VariableRef)}
+    return {k: v for k, v in params.items() if isinstance(v, qml.variable.Variable)}
 
 
 def _check_circuit_and_bind_parameters(quantum_circuit: QuantumCircuit, params: dict, diff_params: dict) -> QuantumCircuit:
@@ -75,7 +75,7 @@ def _check_circuit_and_bind_parameters(quantum_circuit: QuantumCircuit, params: 
         quantum_circuit (QuantumCircuit): the quantum circuit to check and bind the parameters for
         params (dict): dictionary of the parameters in the circuit to their corresponding values
         diff_params (dict): dictionary mapping the differentiable parameters to PennyLane
-            VariableRef instances
+            Variable instances
 
     Returns:
         QuantumCircuit: quantum circuit with bound parameters
@@ -87,7 +87,7 @@ def _check_circuit_and_bind_parameters(quantum_circuit: QuantumCircuit, params: 
         return quantum_circuit
 
     for k in diff_params:
-        # Since we cannot bind VariableRefs to Qiskit circuits,
+        # Since we cannot bind Variables to Qiskit circuits,
         # we must remove them from the binding dictionary before binding.
         del params[k]
 

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -20,6 +20,7 @@ QuanctumCircuit converter module
 This module contains functions for converting Qiskit QuantumCircuit objects
 into PennyLane circuit templates.
 """
+from typing import Dict, Any
 import warnings
 
 import numpy as np
@@ -36,7 +37,7 @@ from pennylane_qiskit.qiskit_device import QISKIT_OPERATION_MAP
 inv_map = {v.__name__: k for k, v in QISKIT_OPERATION_MAP.items()}
 
 
-def _check_parameter_bound(param, var_ref_map):
+def _check_parameter_bound(param: Parameter, var_ref_map: Dict[Parameter, qml.variable.VariableRef]):
     """Utility function determining if a certain parameter in a QuantumCircuit has
     been bound.
 
@@ -49,7 +50,7 @@ def _check_parameter_bound(param, var_ref_map):
         raise ValueError("The parameter {} was not bound correctly.".format(param))
 
 
-def _extract_variable_refs(params: dict) -> dict:
+def _extract_variable_refs(params: Dict[Parameter, Any]) -> Dict[Parameter, qml.variable.VariableRef]:
     """Iterate through the parameter mapping to be bound to the circuit,
     and return a dictionary containing the differentiable parameters.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 qiskit>=0.15
-git+git://github.com/XanaduAI/pennylane.git#egg=pennylane
+pennylane
 numpy
 networkx==2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 qiskit>=0.15
-PennyLane>=0.7.0
+git+git://github.com/XanaduAI/pennylane.git#egg=pennylane
 numpy
 networkx==2.3

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -13,6 +13,11 @@ from pennylane import numpy as np
 from pennylane_qiskit.converter import load, load_qasm, load_qasm_from_file, map_wires
 
 
+THETA = np.linspace(0.11, 3, 5)
+PHI = np.linspace(0.32, 3, 5)
+VARPHI = np.linspace(0.02, 3, 5)
+
+
 class TestConverter:
     """Tests the converter function that allows converting QuantumCircuit objects
      to Pennylane templates."""
@@ -551,7 +556,7 @@ class TestConverter:
 
         quantum_circuit = load(qc)
 
-        with pytest.raises(ValueError, match="could not convert string to float: '{}'".format(angle)):
+        with pytest.raises(TypeError, match="parameter expected, got <class 'str'>"):
             with recorder:
                 quantum_circuit()
 
@@ -946,3 +951,37 @@ class TestConverterIntegration:
             return qml.expval(qml.PauliZ(0))
 
         assert circuit_loaded_qiskit_circuit() == circuit_native_pennylane()
+
+    @pytest.mark.parametrize("analytic", [True])
+    @pytest.mark.parametrize("theta,phi,varphi", list(zip(THETA, PHI, VARPHI)))
+    def test_gradient(self, theta, phi, varphi, tol):
+        """Test that the gradient works correctly"""
+        qc = QuantumCircuit(3)
+        qiskit_params = [Parameter(f"param_{i}") for i in range(3)]
+
+        qc.rx(qiskit_params[0], 0)
+        qc.rx(qiskit_params[1], 1)
+        qc.rx(qiskit_params[2], 2)
+        qc.cnot(0, 1)
+        qc.cnot(1, 2)
+
+        # convert to a PennyLane circuit
+        qc_pl = qml.from_qiskit(qc)
+
+        dev = qml.device("default.qubit", wires=3)
+
+        @qml.qnode(dev)
+        def circuit(params):
+            qiskit_param_mapping = dict(map(list, zip(qiskit_params, params)))
+            qc_pl(qiskit_param_mapping)
+            return qml.expval(qml.PauliX(0) @ qml.PauliY(2))
+
+        dcircuit = qml.grad(circuit, 0)
+        res = dcircuit([theta, phi, varphi])
+        expected = [
+            np.cos(theta) * np.sin(phi) * np.sin(varphi),
+            np.sin(theta) * np.cos(phi) * np.sin(varphi),
+            np.sin(theta) * np.sin(phi) * np.cos(varphi)
+        ]
+
+        assert np.allclose(res, expected, **tol)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -957,7 +957,7 @@ class TestConverterIntegration:
     def test_gradient(self, theta, phi, varphi, tol):
         """Test that the gradient works correctly"""
         qc = QuantumCircuit(3)
-        qiskit_params = [Parameter(f"param_{i}") for i in range(3)]
+        qiskit_params = [Parameter("param_{}".format(i)) for i in range(3)]
 
         qc.rx(qiskit_params[0], 0)
         qc.rx(qiskit_params[1], 1)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -224,6 +224,21 @@ class TestConverter:
             with recorder:
                 quantum_circuit(params={})
 
+    def test_invalid_parameter_expression(self, recorder):
+        """Tests that an operation with multiple parameters raises an error."""
+
+        theta = Parameter('θ')
+        phi = Parameter('φ')
+
+        qc = QuantumCircuit(3, 1)
+        qc.rz(theta*phi, [0])
+
+        quantum_circuit = load(qc)
+
+        with pytest.raises(ValueError, match='PennyLane does not support expressions'):
+            with recorder:
+                quantum_circuit(params={theta: qml.variable.VariableRef(0), phi: qml.variable.VariableRef(1)})
+
     def test_extra_parameters_were_passed(self, recorder):
         """Tests that loading raises an error when extra parameters were passed."""
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -237,7 +237,7 @@ class TestConverter:
 
         with pytest.raises(ValueError, match='PennyLane does not support expressions'):
             with recorder:
-                quantum_circuit(params={theta: qml.variable.VariableRef(0), phi: qml.variable.VariableRef(1)})
+                quantum_circuit(params={theta: qml.variable.Variable(0), phi: qml.variable.Variable(1)})
 
     def test_extra_parameters_were_passed(self, recorder):
         """Tests that loading raises an error when extra parameters were passed."""


### PR DESCRIPTION
**Context:** By expliciting calling `params.val`, the `VariableRef` classes, which allow us to keep track of which operations are using which parameters so that the parameter shift rule can be applied, are being lost in the conversion.

**Description of the changes:**

* The binding logic in the conversion functions has been modified --- now, a mapping is kept of the differentiable Qiskit parameters to the PennyLane variables. The PennyLane variables are then used for operation execution where needed.

* An integration test has been added to ensure that the gradient computation works correctly on converted qiskit circuits.