### PR TITLE
Incrementing the version number to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Bug fixes
 
+### Contributors
+
+# Release 0.8.1
+
+### Bug fixes
+
 * Fixed a bug where gradient computations always returned 0 when
   loading a parametrized Qiskit circuit as a PennyLane template.
   [(#71)](https://github.com/XanaduAI/pennylane-qiskit/pull/71)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,3 @@
-# Release 0.9.0-dev
-
-### New features since last release
-
-### Breaking changes
-
-### Improvements
-
-### Documentation
-
-### Bug fixes
-
-### Contributors
-
 # Release 0.8.1
 
 ### Bug fixes

--- a/pennylane_qiskit/_version.py
+++ b/pennylane_qiskit/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.9.0-dev"
+__version__ = "0.8.1"

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -117,8 +117,8 @@ class QiskitDevice(Device, abc.ABC):
             Default value is ``False``.
     """
     name = "Qiskit PennyLane plugin"
-    pennylane_requires = ">=0.7.0"
-    version = "0.9.0-dev"
+    pennylane_requires = ">=0.8.1"
+    version = "0.8.1"
     plugin_version = __version__
     author = "Xanadu"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit>=0.15
+qiskit>=0.16
 pennylane
 numpy
 networkx==2.3

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 requirements = [
-    "qiskit>=0.14",
-    "pennylane>=0.7.0",
+    "qiskit>=0.16",
+    "pennylane>=0.8.1",
     "numpy"
 ]
 


### PR DESCRIPTION
Incrementing the version number to `0.8.1` and adjusting the requirements:
* increasing the PennyLane requirement from `0.7.0` to `0.8.1` (due to a normalization bug fix)
* increasing the Qiskit requirement from `0.15.0` to `0.16.0`