### PR TITLE
Add default provider options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -205,14 +205,28 @@ Note that, by default, the ``qiskit.ibmq`` device uses the simulator backend
 
     dev.capabilities()['backend']
 
-By default, when getting a Qiskit provider, the official options of ``hub='ibm-q'``, ``group='open'`` and ``project='main'`` will be used. Custom provider options can be passed as keyword arguments when creating a device:
+When getting a ``qiskit.ibmq`` device a Qiskit provider is used to connect to the IBM Q systems.
+
+Custom providers can be passed as arguments when a ``qiskit.ibmq`` device is created:
+
+.. code-block:: python
+
+    from qiskit import IBMQ
+    provider = IBMQ.enable_account("XXX")
+
+    import pennylane as qml
+    dev = qml.device('qiskit.ibmq', wires=2, backend='ibmq_qasm_simulator', provider=provider)
+
+If no provider is passed explicitly, then the official provider is attempted to be used setting the provider options of ``hub='ibm-q'``, ``group='open'`` and ``project='main'``.
+
+Custom provider options can be passed as keyword arguments when creating a device:
 
 .. code-block:: python
 
     import pennylane as qml
     dev = qml.device('qiskit.ibmq', wires=2, backend='ibmq_qasm_simulator', ibmqx_token="XXX", hub='MYHUB', group='MYGROUP', project='MYPROJECT')
 
-Please refer to the `IBMQ provider documentation <https://qiskit.org/documentation/apidoc/ibmq-provider.html>`_ for more details.
+More details on Qiskit providers can be found at the `IBMQ provider documentation <https://qiskit.org/documentation/apidoc/ibmq-provider.html>`_.
 
 .. gettingstarted-end-inclusion-marker-do-not-remove
 Please refer to the `plugin documentation <https://pennylane-qiskit.readthedocs.io/>`_ as

--- a/README.rst
+++ b/README.rst
@@ -205,8 +205,16 @@ Note that, by default, the ``qiskit.ibmq`` device uses the simulator backend
 
     dev.capabilities()['backend']
 
-.. gettingstarted-end-inclusion-marker-do-not-remove
+By default, when getting a Qiskit provider, the official options of ``hub='ibm-q'``, ``group='open'`` and ``project='main'`` will be used. Custom provider options can be passed as keyword arguments when creating a device:
 
+.. code-block:: python
+
+    import pennylane as qml
+    dev = qml.device('qiskit.ibmq', wires=2, backend='ibmq_qasm_simulator', ibmqx_token="XXX", hub='MYHUB', group='MYGROUP', project='MYPROJECT')
+
+Please refer to the `IBMQ provider documentation <https://qiskit.org/documentation/apidoc/ibmq-provider.html>`_ for more details.
+
+.. gettingstarted-end-inclusion-marker-do-not-remove
 Please refer to the `plugin documentation <https://pennylane-qiskit.readthedocs.io/>`_ as
 well as to the `PennyLane documentation <https://pennylane.readthedocs.io/>`_ for further reference.
 

--- a/README.rst
+++ b/README.rst
@@ -217,7 +217,7 @@ Custom providers can be passed as arguments when a ``qiskit.ibmq`` device is cre
     import pennylane as qml
     dev = qml.device('qiskit.ibmq', wires=2, backend='ibmq_qasm_simulator', provider=provider)
 
-If no provider is passed explicitly, then the official provider is attempted to be used setting the provider options of ``hub='ibm-q'``, ``group='open'`` and ``project='main'``.
+If no provider is passed explicitly, then the official provider is used, with options of ``hub='ibm-q'``, ``group='open'`` and ``project='main'``.
 
 Custom provider options can be passed as keyword arguments when creating a device:
 

--- a/README.rst
+++ b/README.rst
@@ -229,6 +229,7 @@ Custom provider options can be passed as keyword arguments when creating a devic
 More details on Qiskit providers can be found at the `IBMQ provider documentation <https://qiskit.org/documentation/apidoc/ibmq-provider.html>`_.
 
 .. gettingstarted-end-inclusion-marker-do-not-remove
+
 Please refer to the `plugin documentation <https://pennylane-qiskit.readthedocs.io/>`_ as
 well as to the `PennyLane documentation <https://pennylane.readthedocs.io/>`_ for further reference.
 

--- a/README.rst
+++ b/README.rst
@@ -224,7 +224,7 @@ Custom provider options can be passed as keyword arguments when creating a devic
 .. code-block:: python
 
     import pennylane as qml
-    dev = qml.device('qiskit.ibmq', wires=2, backend='ibmq_qasm_simulator', ibmqx_token="XXX", hub='MYHUB', group='MYGROUP', project='MYPROJECT')
+    dev = qml.device('qiskit.ibmq', wires=2, backend='ibmq_qasm_simulator', ibmqx_token='XXX', hub='MYHUB', group='MYGROUP', project='MYPROJECT')
 
 More details on Qiskit providers can be found at the `IBMQ provider documentation <https://qiskit.org/documentation/apidoc/ibmq-provider.html>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -212,7 +212,7 @@ Custom providers can be passed as arguments when a ``qiskit.ibmq`` device is cre
 .. code-block:: python
 
     from qiskit import IBMQ
-    provider = IBMQ.enable_account("XXX")
+    provider = IBMQ.enable_account('XYZ')
 
     import pennylane as qml
     dev = qml.device('qiskit.ibmq', wires=2, backend='ibmq_qasm_simulator', provider=provider)

--- a/pennylane_qiskit/ibmq.py
+++ b/pennylane_qiskit/ibmq.py
@@ -107,5 +107,4 @@ class IBMQDevice(QiskitDevice):
 
         # get a provider
         p = provider or IBMQ.get_provider(hub=hub, group=group, project=project)
-
         super().__init__(wires=wires, provider=p, backend=backend, shots=shots, **kwargs)

--- a/pennylane_qiskit/ibmq.py
+++ b/pennylane_qiskit/ibmq.py
@@ -33,7 +33,6 @@ Code details
 ~~~~~~~~~~~~
 """
 import os
-import warnings
 
 from qiskit import IBMQ
 from qiskit.providers.ibmq.exceptions import IBMQAccountError

--- a/pennylane_qiskit/ibmq.py
+++ b/pennylane_qiskit/ibmq.py
@@ -106,4 +106,5 @@ class IBMQDevice(QiskitDevice):
 
         # get a provider
         p = provider or IBMQ.get_provider(hub=hub, group=group, project=project)
+
         super().__init__(wires=wires, provider=p, backend=backend, shots=shots, **kwargs)

--- a/pennylane_qiskit/ibmq.py
+++ b/pennylane_qiskit/ibmq.py
@@ -75,6 +75,11 @@ class IBMQDevice(QiskitDevice):
         token = os.getenv("IBMQX_TOKEN") or kwargs.get("ibmqx_token", None)
         url = os.getenv("IBMQX_URL") or kwargs.get("ibmqx_url", None)
 
+        # Specify a single hub, group and project
+        hub = kwargs.get("hub", 'ibm-q')
+        group = kwargs.get("group", 'open')
+        project = kwargs.get("project", 'main')
+
         if token is not None:
             # token was provided by the user, so attempt to enable an
             # IBM Q account manually
@@ -101,6 +106,6 @@ class IBMQDevice(QiskitDevice):
         # IBM Q account is now enabled
 
         # get a provider
-        p = provider or IBMQ.get_provider()
+        p = provider or IBMQ.get_provider(hub=hub, group=group, project=project)
 
         super().__init__(wires=wires, provider=p, backend=backend, shots=shots, **kwargs)

--- a/tests/test_ibmq.py
+++ b/tests/test_ibmq.py
@@ -55,8 +55,11 @@ def test_custom_provider(monkeypatch):
 
     with monkeypatch.context() as m:
         m.setattr(ibmq.QiskitDevice, "__init__",mock_qiskit_device.mocked_init)
+        m.setattr(ibmq.IBMQ, "enable_account", lambda *args, **kwargs: None)
 
-        dev = qml.device('qiskit.ibmq', wires=2, backend='ibmq_qasm_simulator', provider=mock_provider)
+        # Here mocking to a value such that it is not None
+        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: True)
+        dev = IBMQDevice(wires=2, backend='ibmq_qasm_simulator', provider=mock_provider)
 
     assert mock_qiskit_device.provider == mock_provider
 
@@ -74,8 +77,10 @@ def test_default_provider(monkeypatch):
         m.setattr(ibmq.QiskitDevice, "__init__", mock_qiskit_device.mocked_init)
         m.setattr(ibmq.IBMQ, "get_provider", mock_get_provider)
         m.setattr(ibmq.IBMQ, "enable_account", lambda *args, **kwargs: None)
-        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: None)
-        dev = qml.device('qiskit.ibmq', wires=2, backend='ibmq_qasm_simulator')
+
+        # Here mocking to a value such that it is not None
+        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: True)
+        dev = IBMQDevice(wires=2, backend='ibmq_qasm_simulator')
 
     assert mock_qiskit_device.provider[0] == ()
     assert mock_qiskit_device.provider[1] == {'hub': 'ibm-q', 'group': 'open', 'project': 'main'}
@@ -93,8 +98,10 @@ def test_custom_provider_hub_group_project(monkeypatch):
         m.setattr(ibmq.QiskitDevice, "__init__", mock_qiskit_device.mocked_init)
         m.setattr(ibmq.IBMQ, "get_provider", mock_get_provider)
         m.setattr(ibmq.IBMQ, "enable_account", lambda *args, **kwargs: None)
-        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: None)
-        dev = qml.device('qiskit.ibmq', wires=2, backend='ibmq_qasm_simulator', hub=custom_hub, group=custom_group, project=custom_project)
+
+        # Here mocking to a value such that it is not None
+        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: True)
+        dev = IBMQDevice(wires=2, backend='ibmq_qasm_simulator', hub=custom_hub, group=custom_group, project=custom_project)
 
     assert mock_qiskit_device.provider[0] == ()
     assert mock_qiskit_device.provider[1] == {'hub': custom_hub, 'group': custom_group, 'project': custom_project}

--- a/tests/test_ibmq.py
+++ b/tests/test_ibmq.py
@@ -43,7 +43,7 @@ class MockQiskitDeviceInit:
     is called on by the IBMQDevice"""
 
     def mocked_init(self, wires, provider, backend, shots, **kwargs):
-        """Stores the provider with which QiskitDevice.__init__ was
+        """Stores the provider which QiskitDevice.__init__ was
         called with."""
         self.provider = provider
 

--- a/tests/test_ibmq.py
+++ b/tests/test_ibmq.py
@@ -71,7 +71,7 @@ def test_default_provider(monkeypatch):
     mock_qiskit_device = MockQiskitDeviceInit()
 
     with monkeypatch.context() as m:
-        m.setattr(ibmq.QiskitDevice, "__init__",mock_qiskit_device.mocked_init)
+        m.setattr(ibmq.QiskitDevice, "__init__", mock_qiskit_device.mocked_init)
         m.setattr(ibmq.IBMQ, "get_provider", mock_get_provider)
         m.setattr(ibmq.IBMQ, "enable_account", lambda *args, **kwargs: None)
         m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: None)
@@ -80,9 +80,24 @@ def test_default_provider(monkeypatch):
     assert mock_qiskit_device.provider[0] == ()
     assert mock_qiskit_device.provider[1] == {'hub': 'ibm-q', 'group': 'open', 'project': 'main'}
 
-def test_use_default_provider_when_multiple_exist():
-    """Tests that if multiple providers exist, then the default provider will
-    be used when creating an IBMQ device."""
+def test_custom_provider_hub_group_project(monkeypatch):
+    """Tests that the custom arguments passed during device instantiation are
+    used when calling get_provider."""
+    mock_qiskit_device = MockQiskitDeviceInit()
+
+    custom_hub = "SomeHub"
+    custom_group = "SomeGroup"
+    custom_project = "SomeProject"
+
+    with monkeypatch.context() as m:
+        m.setattr(ibmq.QiskitDevice, "__init__", mock_qiskit_device.mocked_init)
+        m.setattr(ibmq.IBMQ, "get_provider", mock_get_provider)
+        m.setattr(ibmq.IBMQ, "enable_account", lambda *args, **kwargs: None)
+        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: None)
+        dev = qml.device('qiskit.ibmq', wires=2, backend='ibmq_qasm_simulator', hub=custom_hub, group=custom_group, project=custom_project)
+
+    assert mock_qiskit_device.provider[0] == ()
+    assert mock_qiskit_device.provider[1] == {'hub': custom_hub, 'group': custom_group, 'project': custom_project}
 
 
 def test_load_from_disk(token):

--- a/tests/test_ibmq.py
+++ b/tests/test_ibmq.py
@@ -8,6 +8,8 @@ from qiskit import IBMQ
 from qiskit.providers.ibmq.exceptions import IBMQAccountError
 
 from pennylane_qiskit import IBMQDevice
+from pennylane_qiskit import ibmq as ibmq
+from pennylane_qiskit import qiskit_device as qiskit_device
 
 
 @pytest.fixture
@@ -35,6 +37,52 @@ def test_account_already_loaded(token):
     IBMQ.enable_account(token)
     dev = IBMQDevice(wires=1)
     assert dev.provider.credentials.is_ibmq()
+
+class MockQiskitDeviceInit:
+    """A mocked version of the QiskitDevice __init__ method which
+    is called on by the IBMQDevice"""
+
+    def mocked_init(self, wires, provider, backend, shots, **kwargs):
+        """Stores the provider with which QiskitDevice.__init__ was
+        called with."""
+        self.provider = provider
+
+def test_custom_provider(monkeypatch):
+    """Tests that a custom provider can be passed when creating an IBMQ
+    device."""
+    mock_provider = "MockProvider"
+    mock_qiskit_device = MockQiskitDeviceInit()
+
+    with monkeypatch.context() as m:
+        m.setattr(ibmq.QiskitDevice, "__init__",mock_qiskit_device.mocked_init)
+
+        dev = qml.device('qiskit.ibmq', wires=2, backend='ibmq_qasm_simulator', provider=mock_provider)
+
+    assert mock_qiskit_device.provider == mock_provider
+
+def mock_get_provider(*args, **kwargs):
+    """A mock function for the get_provider Qiskit function to record the
+    arguments which it was called with."""
+    return (args, kwargs)
+
+def test_default_provider(monkeypatch):
+    """Tests that the default provider is used when no custom provider was
+    specified."""
+    mock_qiskit_device = MockQiskitDeviceInit()
+
+    with monkeypatch.context() as m:
+        m.setattr(ibmq.QiskitDevice, "__init__",mock_qiskit_device.mocked_init)
+        m.setattr(ibmq.IBMQ, "get_provider", mock_get_provider)
+        m.setattr(ibmq.IBMQ, "enable_account", lambda *args, **kwargs: None)
+        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: None)
+        dev = qml.device('qiskit.ibmq', wires=2, backend='ibmq_qasm_simulator')
+
+    assert mock_qiskit_device.provider[0] == ()
+    assert mock_qiskit_device.provider[1] == {'hub': 'ibm-q', 'group': 'open', 'project': 'main'}
+
+def test_use_default_provider_when_multiple_exist():
+    """Tests that if multiple providers exist, then the default provider will
+    be used when creating an IBMQ device."""
 
 
 def test_load_from_disk(token):


### PR DESCRIPTION
**Problem**
Users who have multiple providers attached to their IBMQ Experience token experience the following error when trying to create a device:

```python
    351             raise IBMQProviderError('No provider matching the criteria')
    352         if len(providers) > 1:
--> 353             raise IBMQProviderError('More than one provider matching the '
    354                                     'criteria')
    355 
IBMQProviderError: 'More than one provider matching the criteria'
```

This is due to the fact that there are more than one provider returned (as the error message suggests) and no specific provider was chosen.

**Solution**

* Updates the documentation with an example of passing a custom provider object to `qml.device`:
```python
    from qiskit import IBMQ
    provider = IBMQ.enable_account("XXX")

    import pennylane as qml
    dev = qml.device('qiskit.ibmq', wires=2, backend='ibmq_qasm_simulator', provider=provider)
```

* Adds the default behaviour of passing default options to `get_provider`: `hub= 'ibm-q'`, `group'='open'`, `project= 'main'`
* Adds the ability to pass custom options as a `hub`, `group` and `project` as keyword arguments as follows:

```python
dev = IBMQDevice(wires=2, backend='ibmq_qasm_simulator', token='XXX', hub=custom_hub, group=custom_group, project=custom_project)
```

(These options can be passed to `qml.device` as well.)

**Drawbacks**
The added unit tests contain Qiskit specific calls and might need to be adjusted whenever these functions are renamed/modified.