### PR TITLE
Qiskit v0.18 updates

### DIFF
--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -204,7 +204,7 @@ class QiskitDevice(Device, abc.ABC):
 
             qregs = list(reversed(qregs))
 
-            # Once a fix is available in Qiskit-Aer, remove the following:
+            # TODO: Once a fix is available in Qiskit-Aer, remove the following:
             par = (x.tolist() for x in par if isinstance(x, np.ndarray))
 
         if operation == "QubitUnitary":

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -69,13 +69,15 @@ QISKIT_OPERATION_MAP = {
     "T": ex.TGate,
 
     # Adding the following for conversion compatibility
-    "CSWAP": ex.FredkinGate,
-    "CRZ": ex.CrzGate,
+    "CSWAP": ex.CSwapGate,
+    "CRX": ex.CRXGate,
+    "CRY": ex.CRYGate,
+    "CRZ": ex.CRZGate,
     "PhaseShift": ex.U1Gate,
     "QubitStateVector": ex.Initialize,
     "U2": ex.U2Gate,
     "U3": ex.U3Gate,
-    "Toffoli": ex.ToffoliGate,
+    "Toffoli": ex.CCXGate,
     "QubitUnitary": ex.UnitaryGate,
 }
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -59,8 +59,8 @@ QISKIT_OPERATION_MAP = {
     "PauliY": ex.YGate,
     "PauliZ": ex.ZGate,
     "Hadamard": ex.HGate,
-    "CNOT": ex.CnotGate,
-    "CZ": ex.CzGate,
+    "CNOT": ex.CXGate,
+    "CZ": ex.CZGate,
     "SWAP": ex.SwapGate,
     "RX": ex.RXGate,
     "RY": ex.RYGate,
@@ -198,6 +198,9 @@ class QiskitDevice(Device, abc.ABC):
                 raise ValueError("State vector must be of length 2**wires.")
 
             qregs = list(reversed(qregs))
+
+            # TODO: once a fix is available in Qiskit-Aer, remove the following:
+            par = (x.tolist() for x in par if isinstance(x, np.ndarray))
 
         if operation == "QubitUnitary":
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -67,7 +67,6 @@ QISKIT_OPERATION_MAP = {
     "RZ": ex.RZGate,
     "S": ex.SGate,
     "T": ex.TGate,
-
     # Adding the following for conversion compatibility
     "CSWAP": ex.CSwapGate,
     "CRX": ex.CRXGate,
@@ -119,9 +118,11 @@ class QiskitDevice(Device, abc.ABC):
     operations = set(_operation_map.keys())
     observables = {"PauliX", "PauliY", "PauliZ", "Identity", "Hadamard", "Hermitian"}
 
-    hw_analytic_warning_message = "The analytic calculation of expectations and variances "\
-                                  "is only supported on statevector backends, not on the {}. "\
-                                  "The obtained result is based on sampling."
+    hw_analytic_warning_message = (
+        "The analytic calculation of expectations and variances "
+        "is only supported on statevector backends, not on the {}. "
+        "The obtained result is based on sampling."
+    )
 
     _eigs = {}
 
@@ -194,14 +195,16 @@ class QiskitDevice(Device, abc.ABC):
         if operation == "QubitStateVector":
 
             if self.backend_name == "unitary_simulator":
-                raise QuantumFunctionError("The QubitStateVector operation is not supported on the unitary simulator backend.")
+                raise QuantumFunctionError(
+                    "The QubitStateVector operation is not supported on the unitary simulator backend."
+                )
 
             if len(par[0]) != 2 ** len(wires):
                 raise ValueError("State vector must be of length 2**wires.")
 
             qregs = list(reversed(qregs))
 
-            # TODO: once a fix is available in Qiskit-Aer, remove the following:
+            # Once a fix is available in Qiskit-Aer, remove the following:
             par = (x.tolist() for x in par if isinstance(x, np.ndarray))
 
         if operation == "QubitUnitary":
@@ -310,7 +313,11 @@ class QiskitDevice(Device, abc.ABC):
         for e in self.obs_queue:
             # Add unitaries if a different expectation value is given
             # Exclude unitary_simulator as it does not support memory=True
-            if hasattr(e, "return_type") and e.return_type == Sample and self.backend_name != 'unitary_simulator':
+            if (
+                hasattr(e, "return_type")
+                and e.return_type == Sample
+                and self.backend_name != "unitary_simulator"
+            ):
                 self.memory = True  # make sure to return samples
 
             if isinstance(e.name, list):
@@ -338,9 +345,7 @@ class QiskitDevice(Device, abc.ABC):
 
         if self.analytic:
             # Raise a warning if backend is a hardware simulator
-            warnings.warn(self.hw_analytic_warning_message.
-                          format(self.backend),
-                          UserWarning)
+            warnings.warn(self.hw_analytic_warning_message.format(self.backend), UserWarning)
 
         # estimate the ev
         return np.mean(self.sample(observable, wires, par))
@@ -354,9 +359,7 @@ class QiskitDevice(Device, abc.ABC):
 
         if self.analytic:
             # Raise a warning if backend is a hardware simulator
-            warnings.warn(self.hw_analytic_warning_message.
-                          format(self.backend),
-                          UserWarning)
+            warnings.warn(self.hw_analytic_warning_message.format(self.backend), UserWarning)
 
         return np.var(self.sample(observable, wires, par))
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -262,7 +262,6 @@ class TestConverter:
         q2 = QuantumRegister(2)
         qc = QuantumCircuit(q2)
 
-        # Calling the QuantumCircuit method unbound
         qiskit_operation(qc, 0.5, q2[0], q2[1])
 
 
@@ -286,7 +285,6 @@ class TestConverter:
         q2 = QuantumRegister(2)
         qc = QuantumCircuit(q2)
 
-        # Calling the QuantumCircuit method unbound
         qc.cry(0.5, q2[0], q2[1])
 
         quantum_circuit = load(qc)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -240,7 +240,8 @@ class TestConverter:
                 quantum_circuit(params={theta: qml.variable.Variable(0), phi: qml.variable.Variable(1)})
 
     def test_extra_parameters_were_passed(self, recorder):
-        """Tests that loading raises an error when extra parameters were passed."""
+        """Tests that loading raises an error when extra parameters were
+        passed."""
 
         theta = Parameter('θ')
         phi = Parameter('φ')
@@ -253,12 +254,17 @@ class TestConverter:
             with recorder:
                 quantum_circuit(params={theta: 0.5, phi: 0.3})
 
-    def test_crz(self, recorder):
-        """Tests loading a circuit with the controlled-Z operation."""
+    @pytest.mark.parametrize("qiskit_operation, pennylane_name", [(QuantumCircuit.crx, "CRX"), (QuantumCircuit.crz, "CRZ")])
+    def test_controlled_rotations(self, qiskit_operation, pennylane_name, recorder):
+        """Tests loading a circuit with two qubit controlled rotations (except
+        for CRY)."""
 
         q2 = QuantumRegister(2)
         qc = QuantumCircuit(q2)
-        qc.crz(0.5, q2[0], q2[1])
+
+        # Calling the QuantumCircuit method unbound
+        qiskit_operation(qc, 0.5, q2[0], q2[1])
+
 
         quantum_circuit = load(qc)
 
@@ -266,9 +272,43 @@ class TestConverter:
             quantum_circuit()
 
         assert len(recorder.queue) == 1
-        assert recorder.queue[0].name == 'CRZ'
+        assert recorder.queue[0].name == pennylane_name
         assert recorder.queue[0].params == [0.5]
         assert recorder.queue[0].wires == [0, 1]
+
+    def test_cry(self, recorder):
+        """Tests that the decomposition of the controlled-Y operation is being
+        loaded."""
+        # This test will be merged into the test_controlled_rotations test once
+        # the native CRY is used in Qiskit and not a set of instructions
+        # yielded from decomposition is being added
+
+        q2 = QuantumRegister(2)
+        qc = QuantumCircuit(q2)
+
+        # Calling the QuantumCircuit method unbound
+        qc.cry(0.5, q2[0], q2[1])
+
+        quantum_circuit = load(qc)
+
+        with recorder:
+            quantum_circuit()
+
+        assert len(recorder.queue) == 4
+        assert recorder.queue[0].name == "U3"
+        assert recorder.queue[0].params == [0.25, 0, 0]
+        assert recorder.queue[0].wires == [1]
+
+        assert recorder.queue[1].name == "CNOT"
+        assert recorder.queue[1].wires == [0, 1]
+
+        assert recorder.queue[2].name == "U3"
+        assert recorder.queue[2].params == [-0.25, 0, 0]
+        assert recorder.queue[2].wires == [1]
+
+        assert recorder.queue[3].name == "CNOT"
+        assert recorder.queue[3].wires == [0, 1]
+
 
     def test_one_qubit_operations_supported_by_pennylane(self, recorder):
         """Tests loading a circuit with the one-qubit operations supported by PennyLane."""
@@ -812,7 +852,7 @@ class TestConverterQasm:
             .format('Barrier')
         assert record[1].message.args[0] == "pennylane_qiskit.converter: The {} instruction is not supported by" \
                                             " PennyLane, and has not been added to the template."\
-            .format('Cu1Gate')
+            .format('CU1Gate')
         assert record[7].message.args[0] == "pennylane_qiskit.converter: The {} instruction is not supported by" \
                                             " PennyLane, and has not been added to the template."\
             .format('Measure')


### PR DESCRIPTION
With the new Qiskit version (`0.18`) certain changes were introduced affecting PennyLane-Qiskit as well.

### List of changes:

**C++/Python conversion**

The following `RuntimeError` is propagated from `Qiskit-Aer`:
```python
RuntimeError: Unable to cast Python instance to C++ type (compile in debug mode for details)
```
A suggested quick fix was used for now.

More details can be found here:
https://github.com/Qiskit/qiskit-aer/issues/692

**Updated names for some gates**

- `CnotGate` will become deprecated and `CXGate` will be used in the future:
https://qiskit.org/documentation/_modules/qiskit/extensions/standard/x.html#CXGate

- `CzGate` will become deprecated and `CZGate` will be used in the future:
https://qiskit.org/documentation/_modules/qiskit/extensions/standard/z.html#CZGate

- The `CRXGate` and the `CRYGate` were added on top of the previous gates available (e.g. `CryGate`). Calling `QuantumCircuit.cry`, however, still yields a decomposition using `U3` and `CNOT` gates.

**Further renames:**
- `ToffoliGate` -> `CCXGate`
- `FredkinGate` -> `CSwapGate`
- `Cu1Gate` -> `CU1Gate`