### PR TITLE
V0.18.3 remove quick fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Breaking changes
 
-* Now supports Qiskit version 0.18.0. As a result of breaking changes
+* Now supports Qiskit version 0.18.3. As a result of breaking changes
   within Qiskit, version 0.17 and below are no longer supported.
   [(#81)](https://github.com/XanaduAI/pennylane-qiskit/pull/81)
+  [(#85)](https://github.com/XanaduAI/pennylane-qiskit/pull/85)
 
 ### Improvements
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -219,11 +219,6 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
             mapped_operation = self._operation_map[operation]
 
-            # TODO: Once Qiskit-Aer version >0.5.0 is released, remove the
-            # following:
-            if any(isinstance(x, np.ndarray) for x in par):
-                par = list(x if not isinstance(x, np.ndarray) else x.tolist() for x in par)
-
             self.qubit_unitary_check(operation, par, wires)
             self.qubit_state_vector_check(operation, par, wires)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit>=0.18
+qiskit>=1.18.3
 pennylane
 numpy
 networkx==2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit>=1.18.3
+qiskit>=0.18.3
 pennylane
 numpy
 networkx==2.3

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 requirements = [
-    "qiskit>=0.18",
+    "qiskit>=0.18.3",
     "pennylane>=0.8.1",
     "numpy"
 ]


### PR DESCRIPTION
**Context**
With the new Qiskit bug fix release `v0.18.3` and Qiskit-Aer `v0.5.1`, the fix for conversion added in #81 is no longer needed.

**Description of changes**
* Removing the conversion
* Pinning `requirements.txt` and `setup.py` to have `qiskit>=0.18.3`