### PR TITLE
Using networkx requirement format from Qiskit-Terra

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 qiskit>=0.19.1
 pennylane
 numpy
-networkx==2.3
+networkx>=2.2;python_version>'3.5'
+networkx>=2.2,<2.4;python_version=='3.5'


### PR DESCRIPTION
**Description**
When running tutorials from the https://github.com/XanaduAI/qml repository, conflicts for the requirements of the `networkx` library may arise.

The following are the relevant requirements
[Qiskit-Terra](https://github.com/Qiskit/qiskit-terra/blob/master/requirements.txt):
`networkx>=2.2;python_version>'3.5'`
`networkx>=2.2,<2.4;python_version=='3.5'`

[PennyLane-Qiskit](https://github.com/XanaduAI/pennylane-qiskit/blob/0f3d845587a7801795b3c1a19de2a3282f9b17c3/requirements.txt#L4):
`networkx==2.3`

[Cirq](https://github.com/quantumlib/Cirq/blob/047421d98441c8c421066c6660ba01f608c7421a/requirements.txt#L7):
`networkx~=2.4`

**Changes**
Turn to the requirements imposed by Qiskit-Terra for `networkx`.