### PR TITLE
Pinning networkx in the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.rst", "r") as fh:
 requirements = [
     "qiskit>=0.19.1",
     "pennylane>=0.9.0",
-    "numpy"
+    "numpy",
     "networkx>=2.2;python_version>'3.5'",
     # Networkx 2.4 is the final version with python 3.5 support.
     "networkx>=2.2,<2.4;python_version=='3.5'",

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ requirements = [
     "qiskit>=0.19.1",
     "pennylane>=0.9.0",
     "numpy"
+    "networkx>=2.2;python_version>'3.5'",
+    # Networkx 2.4 is the final version with python 3.5 support.
+    "networkx>=2.2,<2.4;python_version=='3.5'",
 ]
 
 info = {


### PR DESCRIPTION
* As used for [Qiskit-Terra](https://github.com/Qiskit/qiskit-terra/blob/948671efd960d44597f8fc40094985cccf97e5d8/setup.py#L29), pinning needs to happen in the `setup.py` file as well. This is important for packaging when using a `wheel`.
* Checking the newly released Qiskit  0.19.2 version