### PR TITLE
Check tests against PennyLane master and Qiskit release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 - sudo apt update && sudo apt -y install g++-7 cmake libopenblas-dev
 - pip install pip --upgrade
-- pip install -e git+https://github.com/XanaduAI/pennylane.git#egg=pennylane
+- pip install -e git+https://github.com/XanaduAI/pennylane.git@undo_653
 - pip install --upgrade -r requirements.txt
 - pip install --upgrade pytest pytest-cov wheel codecov
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 - sudo apt update && sudo apt -y install g++-7 cmake libopenblas-dev
 - pip install pip --upgrade
-- pip install -e git+https://github.com/XanaduAI/pennylane.git@undo_653
+- pip install -e git+https://github.com/XanaduAI/pennylane.git@undo_653#egg=pennylane
 - pip install --upgrade -r requirements.txt
 - pip install --upgrade pytest pytest-cov wheel codecov
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 cache: pip
 python:
-- 3.5
 - 3.6
 - 3.7
 - 3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit>=0.19.1
+qiskit>=0.19.2
 pennylane>=0.9.0
 numpy
 networkx>=2.2;python_version>'3.5'


### PR DESCRIPTION
This PR is branched off the last release of this plugin (git tag `v0.9.0`), and runs the continuous integration tests against:

* PennyLane master
* Qiskit current release.